### PR TITLE
Update [...nextauth].ts

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -9,6 +9,7 @@ const options: InitOptions = {
     Providers.GitHub({
       clientId: process.env.GITHUB_ID || '',
       clientSecret: process.env.GITHUB_SECRET || '',
+      scope: "read:user user:email", // read only scopes
     }),
   ],
 


### PR DESCRIPTION
Not sure which branch to try to merge this to... mostly just doing this to get your attention and offer some help.

I'm suggesting this change because I want to participate, but don't want to grant WRITE access to my profile and account as your app is requesting.

I didn't test this, but I think this would lower the scopes to read-only.  

You may need more permissions, but this is a start.  Technically, from my knowledge (which is limited), to use this for "authentication" as you seem to be using it for, you would need the "openid" scope, but github doesn't seem to support that scope.  


Per: https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/
read:user	Grants access to read a user's profile data.
user:email  Grants read access to a user's email addresses.